### PR TITLE
White-list files published to npm rather than use .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-src/
-.npmignore
-.babelrc
-rollup.config.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.3.0",
   "description": "Animated wave component for React",
   "main": "dist/react-wavify.min.js",
+  "files": [
+    "dist",
+    "License.txt",
+    "package.json",
+    "README.org"
+  ],
   "scripts": {
     "build": "rollup -c -o dist/react-wavify.min.js",
     "test": "echo \"No tests \" && exit 0"


### PR DESCRIPTION
This will remove friction of needing to update `.npmignore` when new files are added to the repo.