### PR TITLE
Add Markdown Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+A simple React component which creates an animated wave.
+
+This component is heavily adapted from [Mikołaj Stolarski](https://github.com/grimor)'s awesome [Codepen](https://codepen.io/grimor/pen/qbXLdN)
+and is functionally similar to [Benjamin Grauwin](http://benjamin.grauwin.me/)'s [Wavify](https://github.com/peacepostman/wavify) plug-in.
+
+
+# Installation
+
+**Yarn**
+
+    yarn add react-wavify
+
+**NPM**
+
+    npm install react-wavify
+
+
+# Usage
+
+```js
+import React, { Component } from "react"
+import Wave from 'react-wavify'
+
+class Application extends Component {
+  render () {
+    return (
+      <div>
+        <Wave fill='#f79902'
+              options={{
+                height: 20,
+                amplitude: 20,
+                speed: 0.15,
+                points: 3
+              }}
+        />
+      </div>
+    )
+  }
+}
+```
+
+Simply add the Wave component to the React application using JSX.
+
+The wave's width will scale to fit the parent container.
+
+
+## Props
+
+
+### Fill
+
+The `fill` property can be set to anything that a SVG path can accept (usually gradients or colors).
+
+
+### Options
+
+The component supports a variety of options to affect how the wave is rendered.
+
+Any omitted options will be set to the default value.
+
+-   `height` - Height of the wave relative to the SVG element. **Default:** `20`
+-   `amplitude` - Amplitude of the rendered wave. **Default:** `20`
+-   `speed` - Speed that the wave animation plays at. **Default:** `0.15`
+-   `points` - Amount of points used to form the wave.
+    Can not be less than `1`. **Default:** `3`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist",
     "License.txt",
     "package.json",
-    "README.org"
+    "README.md"
   ],
   "scripts": {
     "build": "rollup -c -o dist/react-wavify.min.js",


### PR DESCRIPTION
npmjs.com does not support Org rendering.

Using Markdown will allow npmjs.com to view it.

Resolves #18 