### PR TITLE
Build demo site after react-wavify

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -42,6 +42,7 @@ action "Publish" {
 }
 
 action "Install Demo" {
+  needs = "Build"
   uses = "nuxt/actions-yarn@master"
   args = "--cwd demo install"
 }


### PR DESCRIPTION
Builds the demo site after the component library to ensure the
demo is built using the latest build.