### PR TITLE
Use React as a peer dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Animated wave component for React",
   "main": "dist/react-wavify.min.js",
+  "src": "src/wave.js",
   "files": [
     "dist",
     "License.txt",
@@ -31,16 +32,19 @@
     "url": "https://github.com/woofers/react-wavify/issues"
   },
   "homepage": "https://github.com/woofers/react-wavify#readme",
+  "peerDependencies": {
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
+    "react": "^16.8.6",
     "rollup": "^1.10.0",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-uglify": "^6.0.2"
   },
   "dependencies": {
-    "react": "^16.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rollup -c -o dist/react-wavify.min.js",
+    "start": "yarn watch",
+    "clean": "rm -rf dist",
+    "build": "rollup -c",
+    "watch": "rollup -c --watch",
     "test": "echo \"No tests \" && exit 0"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,20 +1,24 @@
 import { uglify } from 'rollup-plugin-uglify'
 import babel from 'rollup-plugin-babel'
-const dependencies = Object.keys(require('./package.json').dependencies)
+const json = require('./package.json')
+const dependencies = [
+  ...Object.keys(json.dependencies),
+  ...Object.keys(json.peerDependencies)
+]
 
 const config = {
-    plugins: [
-      babel({
-        exclude: "node_modules/**"
-      }),
-      uglify()
-    ],
-    input: 'src/wave.js',
-    external: dependencies,
-    output: {
-      format: 'cjs',
-      file: 'dist/react-wavify.min.js',
-      name: 'react-wavify'
-    }
+  plugins: [
+    babel({
+      exclude: "node_modules/**"
+    }),
+    uglify()
+  ],
+  input: json.src,
+  external: dependencies,
+  output: {
+    format: 'cjs',
+    file: json.main,
+    name: json.name
+  }
 }
 export default config


### PR DESCRIPTION
Use React as a peer dependency so a wider version range can be used.