### PR TITLE
Allow SVG defs to be passed in as children

### DIFF
--- a/src/wave.js
+++ b/src/wave.js
@@ -96,11 +96,19 @@ class Wave extends Component {
   }
 
   render () {
+    const {
+      style,
+      className,
+      fill,
+      children,
+      ...rest
+    } = this.props
     return (
-      <div style={{ width: '100%', display: 'inline-block', ...this.props.style }}
-             className={this.props.className} ref={this.container}>
+      <div style={{ width: '100%', display: 'inline-block', ...style }}
+             className={className} ref={this.container}>
         <svg width="100%" height="100%" version="1.1" xmlns="http://www.w3.org/2000/svg">
-          <path d={this.state.path} fill={this.props.fill}/>
+          {children}
+          <path d={this.state.path} fill={fill} />
         </svg>
       </div>
     )


### PR DESCRIPTION
Allows SVG defs to be passed in as children to support various features such as gradients
and clipping masks.

Passing in a gradient can be done as follows:

```jsx
<Wave fill={'url(#gradient)'}>
  <defs>
    <linearGradient id="gradient" gradientTransform="rotate(90)">
      <stop offset="5%"  stopColor="gold" />
      <stop offset="95%" stopColor="red" />
    </linearGradient>
  </defs>
</Wave>
```