### PR TITLE
Prevent undefined options props from causing an error

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-wavify-demo",
   "homepage": "http://woofers.github.io/react-wavify",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "dependencies": {
     "@emotion/core": "^10.0.27",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wavify",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Animated wave component for React",
   "main": "dist/react-wavify.min.js",
   "src": "src/wave.js",

--- a/src/wave.js
+++ b/src/wave.js
@@ -86,7 +86,10 @@ class Wave extends Component {
 
   componentDidUpdate(prevProps) {
     const transfer = key => {
-      if (this.options[key] !== this.props.options[key]) {
+      if (typeof this.props.options === 'undefined') {
+        this.options[key] = this.defaults[key]
+      }
+      else if (this.options[key] !== this.props.options[key]) {
         if (typeof this.props.options[key] === 'undefined') {
           this.options[key] = this.defaults[key]
         }


### PR DESCRIPTION
Resolves a bug where passing no `options` props would
cause the prop transfer to fail.